### PR TITLE
Budget headings permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /config/deploy-secrets.yml
 /config/maintenance.yml
 /config/entidades_censo.csv
+/config/census_geozones.csv
 
 /coverage
 

--- a/app/controllers/admin/budget_headings_controller.rb
+++ b/app/controllers/admin/budget_headings_controller.rb
@@ -6,6 +6,7 @@ class Admin::BudgetHeadingsController < Admin::BaseController
   before_action :load_budget
   before_action :load_group
   before_action :load_heading, except: [:index, :new, :create]
+  before_action :load_geozones, only: [:new, :create, :edit, :update]
 
   def index
     @headings = @group.headings.order(:id)
@@ -46,6 +47,10 @@ class Admin::BudgetHeadingsController < Admin::BaseController
 
   private
 
+    def load_geozones
+      @geozones = Geozone.all.order(:name)
+    end
+
     def load_budget
       @budget = Budget.find_by_slug_or_id! params[:budget_id]
     end
@@ -63,7 +68,7 @@ class Admin::BudgetHeadingsController < Admin::BaseController
     end
 
     def budget_heading_params
-      valid_attributes = [:price, :population, :allow_custom_content, :latitude, :longitude]
+      valid_attributes = [:price, :population, :allow_custom_content, :latitude, :longitude, :geozone_id]
       params.require(:budget_heading).permit(*valid_attributes, translation_params(Budget::Heading))
     end
 end

--- a/app/models/custom/budget/heading.rb
+++ b/app/models/custom/budget/heading.rb
@@ -1,0 +1,7 @@
+require_dependency Rails.root.join("app", "models", "budget", "heading").to_s
+
+class Budget
+  class Heading < ApplicationRecord
+    belongs_to :geozone
+  end
+end

--- a/app/models/custom/budget/investment.rb
+++ b/app/models/custom/budget/investment.rb
@@ -1,0 +1,19 @@
+require_dependency Rails.root.join("app", "models", "budget", "investment").to_s
+
+class Budget
+  class Investment < ApplicationRecord
+    def reason_for_not_being_ballotable_by(user, ballot)
+      return permission_problem(user)    if permission_problem?(user)
+      return :not_selected               unless selected?
+      return :no_ballots_allowed         unless budget.balloting?
+      return :invalid_geozone            unless ballotable_by_geozone?(user)
+      return :different_heading_assigned unless ballot.valid_heading?(heading)
+      return :not_enough_money           if ballot.present? && !enough_money?(ballot)
+      return :casted_offline             if ballot.casted_offline?
+    end
+
+    def ballotable_by_geozone?(user)
+      heading.geozone.blank? || heading.geozone == user.geozone
+    end
+  end
+end

--- a/app/models/custom/verification/residence.rb
+++ b/app/models/custom/verification/residence.rb
@@ -5,7 +5,8 @@ class Verification::Residence
   include ActiveModel::Dates
   include ActiveModel::Validations::Callbacks
 
-  attr_accessor :user, :document_number, :document_type, :date_of_birth, :postal_code, :terms_of_service
+  attr_accessor :user, :document_type, :date_of_birth, :postal_code, :terms_of_service
+  attr_writer :document_number
 
   before_validation :call_census_api
 
@@ -17,6 +18,7 @@ class Verification::Residence
   validates :terms_of_service, acceptance: { allow_nil: false }
   validates :postal_code, length: { is: 5 }
 
+  validate :document_number_format
   validate :successful_census_request
   validate :user_is_citizen?
   validate :valid_age?
@@ -46,19 +48,33 @@ class Verification::Residence
     )
   end
 
+  def document_number
+    @document_number&.strip
+  end
+
   private
 
+    def document_number_format
+      return if document_number.length == 9 || ["1", "3"].exclude?(document_type.to_s)
+
+      errors.add(:document_number, "Número de documento inválido") if document_number.length != 9
+    end
+
     def document_number_uniqueness
-      if document_type.to_s == "1" || document_type.to_s == 3
-        errors.add(:document_number, "Numero de documento inválido") if document_number.length != 9
-      elsif (document_type.to_s == "1" || document_type.to_s == "3") && document_number.length >= 8
-        errors.add(:document_number, I18n.t('errors.messages.taken')) if User.where("document_number like '" + document_number.to_s.first(8) + "%'" ).where("id != ?", user.id).any?
-      elsif User.where(document_number: document_number).where("id != ?", user.id).any?
-        errors.add(:document_number, I18n.t('errors.messages.taken'))
-      end
+      return if errors.include?(:document_number)
+
+      taken = if document_number.length >= 8
+                User.where("document_number like '" + document_number.to_s.first(8) + "%'").where("id != ?", user.id).exists?
+              else
+                User.where(document_number: document_number).where("id != ?", user.id).exists?
+              end
+
+      errors.add(:document_number, I18n.t('errors.messages.taken')) if taken
     end
 
     def successful_census_request
+      return if errors.include?(:document_number)
+
       unless @census_api_response.valid?
         errors.add(:document_number, "Ha habido un error al consultar el censo")
       end

--- a/app/models/custom/verification/residence.rb
+++ b/app/models/custom/verification/residence.rb
@@ -73,7 +73,7 @@ class Verification::Residence
     end
 
     def call_census_api
-      @census_api_response = CensusApi.new.call(document_type, document_number, postal_code)
+      @census_api_response = CustomCensusApi.new.call(document_type, document_number, postal_code)
 
       if Rails.env.production? && !user_is_citizen?
         store_failed_attempt

--- a/app/models/custom/verification/residence.rb
+++ b/app/models/custom/verification/residence.rb
@@ -41,7 +41,8 @@ class Verification::Residence
       document_type: document_type,
       date_of_birth: @census_api_response.census_date_of_birth,
       residence_verified_at: Time.now,
-      verified_at: Time.now
+      verified_at: Time.now,
+      geozone: Geozone.find_by(external_code: @census_api_response.geozone_external_code)
     )
   end
 

--- a/app/views/custom/admin/budget_headings/_form.html.erb
+++ b/app/views/custom/admin/budget_headings/_form.html.erb
@@ -1,0 +1,38 @@
+<%= render "shared/globalize_locales", resource: @heading %>
+
+<%= translatable_form_for [:admin, @budget, @group, @heading], url: path do |f| %>
+
+  <%= render "shared/errors", resource: @heading %>
+
+  <div class="row">
+    <%= f.translatable_fields do |translations_form| %>
+      <div class="small-12 medium-6 column end">
+        <%= translations_form.text_field :name, maxlength: 50 %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="row">
+    <div class="small-12 medium-6 column">
+      <%= f.text_field :price, maxlength: 8 %>
+      <%= f.select :geozone_id, options_from_collection_for_select(@geozones, :id, :name, @heading.geozone_id), { include_blank: true } %>
+      <%= f.text_field :population,
+                        maxlength: 8,
+                        data: { toggle_focus: "population-info" },
+                        hint: t("admin.budget_headings.form.population_info") %>
+
+      <%= f.text_field :latitude, maxlength: 22 %>
+      <%= f.text_field :longitude, maxlength: 22 %>
+      <p class="help-text" id="budgets-coordinates-help-text">
+        <%= t("admin.budget_headings.form.coordinates_info") %>
+      </p>
+
+      <%= f.check_box :allow_custom_content %>
+      <p class="help-text" id="budgets-content-blocks-help-text">
+        <%= t("admin.budget_headings.form.content_blocks_info") %>
+      </p>
+
+      <%= f.submit t("admin.budget_headings.form.#{action}"), class: "button success" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/custom/admin/budget_headings/index.html.erb
+++ b/app/views/custom/admin/budget_headings/index.html.erb
@@ -1,0 +1,50 @@
+<%= back_link_to admin_budget_groups_path(@budget), t("admin.budget_headings.index.back") %>
+
+<div class="clear"></div>
+<h2 class="inline-block"><%= "#{@budget.name} / #{@group.name}" %></h2>
+<%= link_to t("admin.budget_headings.form.create"),
+            new_admin_budget_group_heading_path,
+            class: "button float-right" %>
+
+<% if @headings.any? %>
+  <h3><%= t("admin.budget_headings.amount", count: @headings.count) %></h3>
+  <table>
+    <thead>
+      <tr id="<%= dom_id(@group) %>">
+        <th><%= Budget::Heading.human_attribute_name(:name) %></th>
+        <th><%= Budget::Heading.human_attribute_name(:price) %></th>
+        <th><%= Budget::Heading.human_attribute_name(:geozone_id) %></th>
+        <th><%= Budget::Heading.human_attribute_name(:population) %></th>
+        <th><%= Budget::Heading.human_attribute_name(:allow_custom_content) %></th>
+        <th><%= t("admin.actions.actions") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @headings.each do |heading| %>
+        <tr id="<%= dom_id(heading) %>" class="heading">
+          <td><%= link_to heading.name, edit_admin_budget_group_heading_path(@budget, @group, heading) %></td>
+          <td><%= @budget.formatted_heading_price(heading) %></td>
+          <td><%= heading.geozone&.name %></td>
+          <td><%= heading.population %></td>
+          <td>
+            <%= heading.allow_custom_content ? t("admin.shared.true_value") : t("admin.shared.false_value") %>
+          </td>
+          <td>
+            <%= link_to t("admin.actions.edit"),
+                        edit_admin_budget_group_heading_path(@budget, @group, heading),
+                        class: "button hollow" %>
+            <%= link_to t("admin.actions.delete"),
+                        admin_budget_group_heading_path(@budget, @group, heading),
+                        method: :delete,
+                        class: "button hollow alert" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="callout primary clear">
+    <%= t("admin.budget_headings.no_headings") %>
+  </div>
+<% end %>
+

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -40,18 +40,14 @@
                             class: "button margin-top expanded" %>
               <% else %>
                 <div class="callout warning margin-top">
-                  <%= t("budgets.investments.index.sidebar.verified_only",
-                      verify: link_to(t("budgets.investments.index.sidebar.verify_account"),
-                                      verification_path)).html_safe %>
+                  <%= sanitize(t("budgets.investments.index.sidebar.verified_only",
+                                verify: link_to_verify_account)) %>
                 </div>
               <% end %>
             <% else %>
               <div class="callout primary margin-top">
-                <%= t("budgets.investments.index.sidebar.not_logged_in",
-                      sign_in: link_to(t("budgets.investments.index.sidebar.sign_in"),
-                      new_user_session_path),
-                      sign_up: link_to(t("budgets.investments.index.sidebar.sign_up"),
-                      new_user_registration_path)).html_safe %>
+                <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
+                               sign_in: link_to_signin, sign_up: link_to_signup)) %>
               </div>
             <% end %>
           <% end %>

--- a/app/views/custom/layouts/_footer.html.erb
+++ b/app/views/custom/layouts/_footer.html.erb
@@ -56,7 +56,7 @@
           <% if setting['twitter_handle'] %>
             <li class="inline-block">
               <%= link_to "https://twitter.com/#{setting['twitter_handle']}", target: "_blank",
-                           title: t("shared.go_to_page") + t("social.twitter", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                           title: t("shared.go_to_page") + t("social.twitter", org: setting['org_name']) + t('shared.target_blank') do %>
                               <span class="show-for-sr"><%= t("social.twitter", org: setting['org_name']) %></span>
                               <span class="icon-twitter" aria-hidden="true"></span>
               <% end %>
@@ -65,7 +65,7 @@
           <% if setting['facebook_handle'] %>
             <li class="inline-block">
               <%= link_to "https://www.facebook.com/#{setting['facebook_handle']}/", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.facebook", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                          title: t("shared.go_to_page") + t("social.facebook", org: setting['org_name']) + t('shared.target_blank') do %>
                           <span class="show-for-sr"><%= t("social.facebook", org: setting['org_name']) %></span>
                           <span class="icon-facebook" aria-hidden="true"></span>
               <% end %>
@@ -74,7 +74,7 @@
           <%  if setting['blog_url'] %>
             <li class="inline-block">
               <%= link_to setting['blog_url'], target: "_blank",
-                          title: t("shared.go_to_page") + t("social.blog", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                          title: t("shared.go_to_page") + t("social.blog", org: setting['org_name']) + t('shared.target_blank') do %>
                           <span class="show-for-sr"><%= t("social.blog", org: setting['org_name']) %></span>
                           <span class="icon-blog" aria-hidden="true"></span>
               <% end %>
@@ -83,7 +83,7 @@
           <% if setting['youtube_handle'] %>
             <li class="inline-block">
               <%= link_to "https://www.youtube.com/#{setting['youtube_handle']}", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.youtube", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                          title: t("shared.go_to_page") + t("social.youtube", org: setting['org_name']) + t('shared.target_blank') do %>
                           <span class="show-for-sr"><%= t("social.youtube", org: setting['org_name']) %></span>
                           <span class="icon-youtube" aria-hidden="true"></span>
               <% end %>
@@ -92,7 +92,7 @@
           <% if setting['telegram_handle'] %>
             <li class="inline-block">
               <%= link_to "https://www.telegram.me/#{setting['telegram_handle']}", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.telegram", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                          title: t("shared.go_to_page") + t("social.telegram", org: setting['org_name']) + t('shared.target_blank') do %>
                           <span class="show-for-sr"><%= t("social.telegram", org: setting['org_name']) %></span>
                           <span class="icon-telegram" aria-hidden="true"></span>
               <% end %>
@@ -101,7 +101,7 @@
           <% if setting['instagram_handle'] %>
             <li class="inline-block">
               <%= link_to "https://www.instagram.com/#{setting['instagram_handle']}", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.instagram", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                          title: t("shared.go_to_page") + t("social.instagram", org: setting['org_name']) + t('shared.target_blank') do %>
                           <span class="show-for-sr"><%= t("social.instagram", org: setting['org_name']) %></span>
                           <span class="icon-instagram" aria-hidden="true"></span>
               <% end %>

--- a/app/views/custom/pages/help/_budgets.html.erb
+++ b/app/views/custom/pages/help/_budgets.html.erb
@@ -20,7 +20,8 @@
 
     <figure>
       <%= image_tag "help/budgets_#{I18n.locale}.png", alt: t("pages.help.budgets.image_alt") %>
-      <figcaption><%= t("pages.help.budgets.figcaption_html") %></figcaption>
+            <figcaption><%= t("pages.help.budgets.figcaption") %></figcaption>
+
     </figure>
   </div>
 </div>

--- a/app/views/custom/verification/residence/new.html.erb
+++ b/app/views/custom/verification/residence/new.html.erb
@@ -41,7 +41,7 @@
       <div class="row">
         <div class="small-12 medium-8">
           <div class="small-12 medium-3 column">
-          <%= f.label t("verification.residence.new.document_type_label") %>
+          <%= f.label t("management.account_info.document_type_label") %>
           <%= f.select :document_type, document_types, prompt: "", label: false %>
           </div>
           <div class="small-12 medium-5 column end">
@@ -66,7 +66,7 @@
       </div>
 
       <div class="date-of-birth small-12 medium-6 clear">
-      <%= f.label t("verification.residence.new.date_of_birth") %>
+      <%= f.label t("management.date_of_birth") %>
       <%= f.date_select :date_of_birth,
                         prompt: true,
                         start_year: 1900, end_year: 16.years.ago.year,

--- a/app/views/custom/verification/residence/new.html.erb
+++ b/app/views/custom/verification/residence/new.html.erb
@@ -87,7 +87,7 @@
           <span class="checkbox">
             <%= t("verification.residence.new.accept_terms_text",
                 terms_url: link_to(t("verification.residence.new.terms"), "/census_terms",
-                title: t('shared.target_blank_html'),
+                title: t('shared.target_blank'),
                 target: "_blank")).html_safe
             %>
           </span>

--- a/config/application_custom.rb
+++ b/config/application_custom.rb
@@ -39,7 +39,7 @@ I18n.enforce_available_locales = false
 
 module Consul
   class Application < Rails::Application
-    require Rails.root.join("lib/custom/census_api")
+    require Rails.root.join("lib/custom/custom_census_api")
     require Rails.root.join("lib/custom/census_caller")
 
     config.i18n.default_locale = :es

--- a/config/application_custom.rb
+++ b/config/application_custom.rb
@@ -1,5 +1,6 @@
 
 census_entities = []
+census_geozones = []
 
 CSV.foreach(Rails.root.join("config", "entidades_censo.csv"), headers: true, col_sep: "\;") do |row|
   census_entities.append({
@@ -13,7 +14,11 @@ CSV.foreach(Rails.root.join("config", "entidades_censo.csv"), headers: true, col
   })
 end
 
+census_geozones = CSV.open(Rails.root.join("config", "census_geozones.csv"), headers: true).map(&:to_h)
+
 CENSUS_ENTITIES = census_entities.freeze
+CENSUS_GEOZONES = census_geozones.freeze
+
 postal_codes = CENSUS_ENTITIES.map { |entity| entity[:postal_code] }.uniq
 
 census_dictionary = {}
@@ -23,7 +28,10 @@ postal_codes.each do |code|
                                            .map { |e| e[:entity_code] }.uniq
 end
 
+geozones_dictionary = CENSUS_GEOZONES.map { |e| [e["entity_code"], e["geozone_external_code"]] }.to_h.except(nil)
+
 CENSUS_DICTIONARY = census_dictionary.freeze
+GEOZONES_DICTIONARY= geozones_dictionary.freeze
 
 # puts JSON.pretty_generate(CENSUS_DICTIONARY) if Rails.env.development?
 

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -1,0 +1,5 @@
+es:
+  activerecord:
+    attributes:
+      budget/heading:
+        geozone_id: "Ámbito de actuación (opcional)"

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -3,6 +3,7 @@ es:
     ballots:
       reasons_for_not_balloting:
         different_heading_assigned: Ya votaste en una sección distinta del presupuesto.
+        invalid_geozone: Solo puedes votar proyectos de tu zona.
     phase:
       accepting: Presentación de propuestas
     index:

--- a/config/locales/custom/es/verification.yml
+++ b/config/locales/custom/es/verification.yml
@@ -2,4 +2,5 @@ es:
   verification:
     residence:
       new:
+        postal_code: Código postal
         error_verifying_census: El Padrón no pudo verificar tu información. Por favor, confirma que tus datos de empadronamiento sean correctos llamando a la Diputación o visitando una oficina de Atención al ciudadano.

--- a/config/locales/custom/es/verification.yml
+++ b/config/locales/custom/es/verification.yml
@@ -3,4 +3,6 @@ es:
     residence:
       new:
         postal_code: Código postal
+        document_number_help_title: Ayuda
+        document_number_help_text_html: "<strong>DNI</strong>: 12345678A<br> <strong>Pasaporte</strong>: AAA000001<br> <strong>Tarjeta de residencia</strong>: X1234567P"
         error_verifying_census: El Padrón no pudo verificar tu información. Por favor, confirma que tus datos de empadronamiento sean correctos llamando a la Diputación o visitando una oficina de Atención al ciudadano.

--- a/db/migrate/20200612102641_add_geozones_reference_to_budget_headings.rb
+++ b/db/migrate/20200612102641_add_geozones_reference_to_budget_headings.rb
@@ -1,0 +1,5 @@
+class AddGeozonesReferenceToBudgetHeadings < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :budget_headings, :geozone, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191108173350) do
+ActiveRecord::Schema.define(version: 20200612102641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -216,6 +216,8 @@ ActiveRecord::Schema.define(version: 20191108173350) do
     t.text     "longitude"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "geozone_id"
+    t.index ["geozone_id"], name: "index_budget_headings_on_geozone_id", using: :btree
     t.index ["group_id"], name: "index_budget_headings_on_group_id", using: :btree
   end
 
@@ -1605,6 +1607,7 @@ ActiveRecord::Schema.define(version: 20191108173350) do
   add_foreign_key "administrators", "users"
   add_foreign_key "budget_administrators", "administrators"
   add_foreign_key "budget_administrators", "budgets"
+  add_foreign_key "budget_headings", "geozones"
   add_foreign_key "budget_investments", "communities"
   add_foreign_key "budget_valuators", "budgets"
   add_foreign_key "budget_valuators", "valuators"

--- a/lib/custom/census_api.rb
+++ b/lib/custom/census_api.rb
@@ -14,6 +14,7 @@ class CensusApi
         get_response_body(document_type, document_number, nonce, entity_id(entity_code)),
         nonce
       )
+      response.geozone_external_code = census_geozone_external_code(entity_code)
 
       break if response.is_citizen?
     end
@@ -23,6 +24,10 @@ class CensusApi
 
   def census_entities_codes(postal_code)
     CENSUS_DICTIONARY[postal_code] || []
+  end
+
+  def census_geozone_external_code(entity_code)
+    GEOZONES_DICTIONARY[entity_code]
   end
 
   def entity_id(id)
@@ -37,7 +42,8 @@ class CensusApi
       :response_nonce,
       :census_birth_time,
       :census_date_of_birth,
-      :census_age
+      :census_age,
+      :geozone_external_code
     )
 
     def initialize(body, request_nonce)

--- a/lib/custom/census_caller.rb
+++ b/lib/custom/census_caller.rb
@@ -1,7 +1,7 @@
 class CensusCaller
 
   def call(document_type, document_number, postal_code)
-    response = CensusApi.new.call(document_type, document_number, postal_code)
+    response = CustomCensusApi.new.call(document_type, document_number, postal_code)
     response = LocalCensus.new.call(document_type, document_number) unless response.valid?
 
     response

--- a/lib/custom/custom_census_api.rb
+++ b/lib/custom/custom_census_api.rb
@@ -31,7 +31,7 @@ class CustomCensusApi
   end
 
   def entity_id(id)
-    Rails.env.production? ? id : 999
+    Rails.env.development? ? 999 : id
   end
 
   class Response

--- a/lib/custom/custom_census_api.rb
+++ b/lib/custom/custom_census_api.rb
@@ -1,6 +1,6 @@
 require "csv"
 
-class CensusApi
+class CustomCensusApi
 
   def call(document_type, document_number, postal_code)
     response = Response.new(nil, nil)

--- a/spec/models/custom/budget/investment.rb
+++ b/spec/models/custom/budget/investment.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+describe Budget::Investment do
+  describe "#ballotable_by_geozone?" do
+    describe "Final Voting with geozone" do
+      describe "Permissions" do
+        let(:geozone)     { create(:geozone) }
+        let(:budget)      { create(:budget) }
+        let(:heading)     { create(:budget_heading, budget: budget, geozone: geozone) }
+        let(:user)        { create(:user, :level_two, geozone: geozone) }
+        let(:luser)       { create(:user) }
+        let(:ballot)      { create(:budget_ballot, budget: budget) }
+        let(:investment)  { create(:budget_investment, :selected, budget: budget, heading: heading) }
+
+        describe "#reason_for_not_being_ballotable_by" do
+          it "accepts users when heading geozone is blank" do
+            budget.phase = "balloting"
+            group = create(:budget_group, budget: budget)
+            heading_without_geozone = create(:budget_heading, group: group)
+            investment = create(
+              :budget_investment,
+              :selected,
+              budget: budget,
+              heading: heading_without_geozone
+            )
+            ballot = create(
+              :budget_ballot,
+              user: user,
+              budget: budget,
+              investments: [investment]
+            )
+            expect(investment.reason_for_not_being_ballotable_by(user, ballot)).to be_nil
+          end
+
+          it "rejects users when heading geozone is present and user geozone is not the same" do
+            budget.phase = "balloting"
+            heading.geozone = create(:geozone, name: "Boston")
+            user.geozone =  create(:geozone, name: "California")
+            expect(investment.reason_for_not_being_ballotable_by(user, ballot)).to eq(:invalid_geozone)
+          end
+
+          it "accepts users when heading geozone is present and user geozone is the same" do
+            budget.phase = "balloting"
+            expect(investment.reason_for_not_being_ballotable_by(user, ballot)).to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## References

## Objectives

 * Set geozone of users on census verification
 * Add a belongs_to association in budgets headings with geozones and allow admins to manage it from budgets headings admin panel.
 * Allow users to only vote investments related with their geozone via heading

## Visual Changes

In budgets headings admin section a new column has been added to index and a field to the new/edit forms with their association with geozones:

<img width="931" alt="Screen Shot 2020-06-16 at 11 58 51" src="https://user-images.githubusercontent.com/446459/84760822-df20a500-afc8-11ea-865c-d3b1cb3e3682.png">

<img width="542" alt="Screen Shot 2020-06-16 at 11 59 21" src="https://user-images.githubusercontent.com/446459/84760829-dfb93b80-afc8-11ea-9b31-73514e858206.png">
 

## Notes

* To link users to geozone properly on verification there is a configuration file which has to be uploaded containing associations between user entities (municipalities) and geozones. The geozones are identified by using an `external_code` which has to be added from /admin/geozones for each. These are the external codes:

<img width="361" alt="Screen Shot 2020-06-16 at 11 53 26" src="https://user-images.githubusercontent.com/446459/84760266-117dd280-afc8-11ea-9aa2-cb725199a5b0.png">
