### PR TITLE
Restrict proposals creation with geozone

### DIFF
--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -4,6 +4,7 @@ module Abilities
 
     def initialize(user)
       merge Abilities::Everyone.new(user)
+      merge Abilities::CustomVerified.new(user)
 
       can [:read, :update], User, id: user.id
 
@@ -46,7 +47,6 @@ module Abilities
 
       can :create, Comment
       can :create, Debate
-      can [:create, :created], Proposal
       can :create, Legislation::Proposal
 
       can :suggest, Debate

--- a/app/models/custom/abilities/custom_verified.rb
+++ b/app/models/custom/abilities/custom_verified.rb
@@ -1,0 +1,11 @@
+module Abilities
+  class CustomVerified
+    include CanCan::Ability
+
+    def initialize(user)
+      if user.level_two_or_three_verified? && user.geozone.present?
+        can [:create, :created], Proposal, geozone_id: user.geozone_id
+      end
+    end
+  end
+end

--- a/app/views/custom/account/show.html.erb
+++ b/app/views/custom/account/show.html.erb
@@ -1,0 +1,145 @@
+<div class="row account">
+  <div class="small-12 column">
+    <div class="float-right text-right">
+      <%= link_to t("account.show.change_credentials_link"), edit_user_registration_path, class: "button hollow" %>
+      <br>
+      <%= link_to t("account.show.erase_account_link"), users_registrations_delete_form_path, class: "delete" %>
+    </div>
+
+    <%= avatar_image(@account, seed: @account.id, size: 100, class: "margin-bottom") %>
+
+    <h1 class="inline-block"><%= t("account.show.title") %></h1>
+
+    <%= form_for @account, as: :account, url: account_path do |f| %>
+      <%= render "shared/errors", resource: @account %>
+
+      <div class="row">
+        <div class="small-12 medium-7 column">
+
+          <h2><%= t("account.show.personal") %></h2>
+
+          <div class="small-12 medium-10">
+            <% if @account.organization? %>
+              <%= f.fields_for :organization do |fo| %>
+                <%= fo.text_field :name, autofocus: true, maxlength: Organization.name_max_length, placeholder: t("account.show.organization_name_label") %>
+                <%= fo.text_field :responsible_name, autofocus: true, maxlength: Organization.responsible_name_max_length, placeholder: t("account.show.organization_responsible_name_placeholder") %>
+              <% end %>
+              <%= f.text_field :phone_number, placeholder: t("account.show.phone_number_label") %>
+
+            <% else %>
+              <%= f.text_field :username, maxlength: User.username_max_length, placeholder: t("account.show.username_label") %>
+            <% end %>
+          </div>
+
+          <div>
+            <%= f.check_box :public_activity %>
+          </div>
+
+          <div>
+            <%= f.check_box :public_interests %>
+          </div>
+
+          <% if @account.email.present? %>
+            <h2><%= t("account.show.notifications") %></h2>
+
+            <div>
+              <%= f.check_box :email_on_comment %>
+            </div>
+
+            <div>
+              <%= f.check_box :email_on_comment_reply %>
+            </div>
+
+            <div>
+              <%= f.check_box :newsletter %>
+            </div>
+
+            <div>
+              <%= f.check_box :email_digest %>
+            </div>
+
+            <div>
+              <%= f.check_box :email_on_direct_message %>
+            </div>
+          <% end %>
+
+          <% if @account.official_level == 1 %>
+            <div>
+              <%= f.check_box :official_position_badge %>
+            </div>
+          <% end %>
+
+          <% if feature?("user.recommendations") %>
+            <h2><%= t("account.show.recommendations") %></h2>
+
+            <% if feature?("user.recommendations_on_debates") %>
+              <div>
+                <%= f.check_box :recommended_debates %>
+              </div>
+            <% end %>
+
+            <% if feature?("user.recommendations_on_proposals") %>
+              <div>
+                <%= f.check_box :recommended_proposals %>
+              </div>
+            <% end %>
+          <% end %>
+
+          <%= f.submit t("account.show.save_changes_submit"), class: "button margin-top" %>
+        </div>
+
+        <div class="user-permissions small-12 medium-5 column">
+          <h2><%= t("account.show.user_permission_title") %></h2>
+
+          <p><%= t("account.show.user_permission_info") %></p>
+
+          <ul>
+            <li><span class="icon-check"></span>&nbsp;<%= t("account.show.user_permission_debates") %></li>
+            <li><span class="<%= can?(:create, Proposal) ? "icon-check" : "icon-x" %>"></span>&nbsp;<%= t("account.show.user_permission_proposal") %></li>
+            <li>
+              <% if current_user.level_two_or_three_verified? %>
+                <span class="icon-check"></span>
+              <% else %>
+                <span class="icon-x"></span>
+              <% end %>
+              <%= t("account.show.user_permission_support_proposal") %>
+            </li>
+            <li>
+              <% if current_user.level_three_verified? %>
+                <span class="icon-check"></span>
+              <% else %>
+                <span class="icon-x"></span>
+              <% end %>
+              <%= t("account.show.user_permission_votes") %>
+            </li>
+          </ul>
+
+          <p>
+            <span><%= t("account.show.user_permission_verify_info") %></span>
+          </p>
+          <p>
+            <%= t("account.show.user_permission_verify") %>
+          </p>
+
+          <% unless @account.organization? %>
+            <div>
+              <span class="verify-account">
+                <% if current_user.level_three_verified? %>
+                  <p class="already-verified">
+                    <span class="icon-check"></span>
+                    <%= t("account.show.verified_account") %>
+                  </p>
+                <% elsif current_user.level_two_verified? %>
+                  <%= link_to t("account.show.finish_verification"), verification_path, class: "button success" %>
+                <% else %>
+                  <%= link_to t("account.show.verify_my_account"), verification_path, class: "button success" %>
+                <% end %>
+              </span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/custom/debates/new.html.erb
+++ b/app/views/custom/debates/new.html.erb
@@ -1,0 +1,32 @@
+<div class="debate-form row">
+
+  <div class="small-12 medium-9 column">
+    <%= back_link_to debates_path %>
+
+    <h1><%= t("debates.new.start_new") %></h1>
+      <div data-alert class="callout primary">
+        <% if can? :create, Proposal %>
+          <%= sanitize(t("debates.new.info",
+          info_link: link_to(t("debates.new.info_link"), new_proposal_path))) %>
+        <% end %>
+
+        <% if feature?(:help_page) %>
+          <%= link_to help_path, title: t("shared.target_blank"), target: "_blank" do %>
+            <strong><%= t("debates.new.more_info") %></strong>
+          <% end %>
+        <% end %>
+      </div>
+    <%= render "form" %>
+  </div>
+
+  <div class="small-12 medium-3 column">
+    <span class="icon-debates float-right"></span>
+    <h2><%= t("debates.new.recommendations_title") %></h2>
+    <ul class="recommendations">
+      <li><%= t("debates.new.recommendation_one") %></li>
+      <li><%= t("debates.new.recommendation_two") %></li>
+      <li><%= t("debates.new.recommendation_three") %></li>
+      <li><%= t("debates.new.recommendation_four") %></li>
+    </ul>
+  </div>
+</div>

--- a/app/views/custom/proposals/_form.html.erb
+++ b/app/views/custom/proposals/_form.html.erb
@@ -1,0 +1,112 @@
+<% geozone_select_options = Geozone.where(id: current_user.geozone_id).map { |g| [g.name, g.id] } %>
+<%= render "shared/globalize_locales", resource: @proposal %>
+
+<%= translatable_form_for(@proposal, url: form_url) do |f| %>
+
+  <%= render "shared/errors", resource: @proposal %>
+
+  <div class="row column">
+    <%= f.translatable_fields do |translations_form| %>
+      <div class="small-12 column">
+        <%= translations_form.text_field :title,
+              maxlength: Proposal.title_max_length,
+              data: { js_suggest_result: "js_suggest_result",
+                      js_suggest: ".js-suggest",
+                      js_url: suggest_proposals_path } %>
+      </div>
+      <div class="js-suggest" data-locale="<%= translations_form.locale %>"></div>
+
+      <div class="small-12 column">
+        <%= translations_form.text_area :summary,
+                                        rows: 4, maxlength: 200,
+                                        hint: t("proposals.form.proposal_summary_note") %>
+      </div>
+
+      <div class="small-12 column">
+        <%= translations_form.text_area :description,
+                                        maxlength: Proposal.description_max_length,
+                                        class: "html-area" %>
+      </div>
+    <% end %>
+
+    <%= f.invisible_captcha :subtitle %>
+
+    <div class="small-12 column">
+      <%= f.text_field :video_url, hint: t("proposals.form.proposal_video_url_note") %>
+    </div>
+
+    <% if feature?(:allow_images) %>
+      <div class="images small-12 column">
+        <%= render "images/nested_image", imageable: @proposal, f: f %>
+      </div>
+    <% end %>
+
+    <% if feature?(:allow_attached_documents) %>
+      <div class="documents small-12 column">
+        <%= render "documents/nested_documents", documentable: @proposal, f: f %>
+      </div>
+    <% end %>
+
+    <div class="small-12 medium-6 column">
+      <%= f.select :geozone_id, geozone_select_options %>
+    </div>
+
+    <% if feature?(:map) %>
+      <div class="small-12 column">
+
+        <%= render "map_locations/form_fields",
+                   form:     f,
+                   map_location: @proposal.map_location || MapLocation.new,
+                   label:    t("proposals.form.map_location"),
+                   help:     t("proposals.form.map_location_instructions"),
+                   remove_marker_label: t("proposals.form.map_remove_marker"),
+                   parent_class: "proposal",
+                   i18n_namespace: "proposals" %>
+
+      </div>
+    <% end %>
+
+    <div class="small-12 column">
+      <%= f.label :tag_list, t("proposals.form.tags_label") %>
+      <p class="help-text" id="tag-list-help-text"><%= t("proposals.form.tags_instructions") %></p>
+
+      <div id="category_tags" class="tags">
+        <%= f.label :category_tag_list, t("proposals.form.tag_category_label") %>
+        <% @categories.each do |tag| %>
+          <a class="js-add-tag-link"><%= tag.name %></a>
+        <% end %>
+      </div>
+
+      <br>
+      <%= f.text_field :tag_list, value: @proposal.tag_list.to_s,
+                        label: false,
+                        placeholder: t("proposals.form.tags_placeholder"),
+                        class: "js-tag-list tag-autocomplete",
+                        aria: { describedby: "tag-list-help-text" },
+                        data: { js_url: suggest_tags_path } %>
+    </div>
+
+    <% if current_user.unverified? %>
+      <div class="small-12 column">
+        <%= f.text_field :responsible_name,
+          hint: t("proposals.form.proposal_responsible_name_note") %>
+      </div>
+    <% end %>
+
+    <div class="small-12 column">
+      <% if @proposal.new_record? %>
+        <%= f.check_box :terms_of_service,
+          title: t("form.accept_terms_title"),
+          label: t("form.accept_terms",
+                   policy: link_to(t("form.policy"), "/privacy", target: "blank"),
+                   conditions: link_to(t("form.conditions"), "/conditions", target: "blank")
+                  ) %>
+      <% end %>
+    </div>
+
+    <div class="actions small-12 column">
+      <%= f.submit(class: "button", value: t("proposals.#{action_name}.form.submit_button")) %>
+    </div>
+  </div>
+<% end %>
+

--- a/app/views/custom/proposals/index.html.erb
+++ b/app/views/custom/proposals/index.html.erb
@@ -1,0 +1,151 @@
+<% provide :title do %><%= t("proposals.index.title") %><% end %>
+<% content_for :header_addon do %>
+  <%= render "shared/search_form",
+             search_path: proposals_path(page: 1),
+             i18n_namespace: "proposals.index.search_form" %>
+<% end %>
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: proposals_url %>
+<% end %>
+
+<main>
+  <% if [
+          @search_terms,
+          @advanced_search_terms,
+          @tag_filter,
+          params[:retired].present?,
+          params[:selected].present?
+        ].any? %>
+    <div class="highlight no-margin-top padding margin-bottom">
+      <div class="row">
+        <div class="small-12 column">
+          <% if @search_terms || @advanced_search_terms %>
+            <h2><%= t("shared.search_results") %></h2>
+            <p>
+              <%= page_entries_info @proposals %>
+              <% if !@advanced_search_terms %>
+                <%= sanitize(
+                  t("proposals.index.search_results", count: @proposals.size, search_term: @search_terms)
+                ) %>
+              <% end %>
+            <p>
+          <% elsif @tag_filter %>
+            <h2><%= t("shared.search_results") %></h2>
+            <p>
+              <%= page_entries_info @proposals %>
+              <%= t("proposals.index.filter_topic", count: @proposals.size, topic: @tag_filter) %>
+            </p>
+          <% elsif params[:retired].present? %>
+            <h2><%= t("proposals.index.retired_proposals") %></h2>
+          <% elsif params[:selected].present? %>
+            <h2><%= t("proposals.index.selected_proposals") %></h2>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% else %>
+    <%= render "shared/section_header", i18n_namespace: "proposals.index.section_header", image: "proposals" %>
+  <% end %>
+
+  <% if show_recommended_proposals? %>
+    <%= render "shared/recommended_index", recommended: @recommended_proposals,
+                                           disable_recommendations_path: recommendations_disable_proposals_path,
+                                           namespace: "proposals" %>
+  <% end %>
+
+  <div class="row">
+    <div id="proposals" class="proposals-list small-12 medium-9 column">
+
+      <% if has_banners? %>
+        <%= render "shared/banner" %>
+      <% end %>
+
+      <% if show_featured_proposals? %>
+        <div id="featured-proposals" class="row featured-proposals">
+          <div class="small-12 column">
+            <h2>
+              <%= t("proposals.index.featured_proposals") %>
+            </h2>
+          </div>
+          <% @featured_proposals.each do |featured_proposal| %>
+            <%= render "featured_proposal", proposal: featured_proposal %>
+          <% end %>
+        </div>
+      <% end %>
+
+      <% unless params[:selected].present? %>
+        <div class="row">
+          <div class="small-12 column">
+            <%= render "view_mode" %>
+          </div>
+        </div>
+      <% end %>
+
+      <% unless params[:retired].present? || params[:selected].present? %>
+        <%= render "shared/advanced_search",
+                   search_path: proposals_path(page: 1) %>
+      <% end %>
+
+      <% unless params[:selected].present? %>
+        <%= render "shared/order_links", i18n_namespace: "proposals.index" %>
+      <% end %>
+
+      <% if @proposals.any? && can?(:create, Proposal) %>
+        <div class="show-for-small-only">
+          <%= link_to t("proposals.index.start_proposal"),
+                      new_proposal_path,
+                      class: "button expanded" %>
+        </div>
+      <% end %>
+
+      <div id="proposals-list">
+        <% if @proposals.any? || current_user.blank? %>
+          <% if proposals_default_view? %>
+            <%= render partial: "proposals/proposal", collection: @proposals %>
+          <% else %>
+            <% @proposals.each do |proposal| %>
+              <%= render "/proposals/proposal_minimal", proposal: proposal %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <%= empty_recommended_proposals_message_text(current_user) %>
+        <% end %>
+        <%= paginate @proposals %>
+
+        <% unless @search_terms || @advanced_search_terms || @tag_filter %>
+          <div id="section_help" class="margin" data-magellan-target="section_help">
+            <p class="lead">
+              <strong><%= t("proposals.index.section_footer.title") %></strong>
+            </p>
+            <p><%= t("proposals.index.section_footer.description") %></p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="small-12 medium-3 column">
+      <aside class="margin-bottom">
+        <% if can? :create, Proposal %>
+          <%= link_to t("proposals.index.start_proposal"),
+                      new_proposal_path,
+                      class: "button expanded" %>
+        <% end %>
+        <div class="sidebar-divider"></div>
+        <h2 class="sidebar-title"><%= t("proposals.index.selected_proposals") %></h2>
+        <br>
+        <p class="small">
+          <%= link_to t("proposals.index.selected_proposals_link"), proposals_path(selected: "all") %>
+        </p>
+
+        <% if params[:retired].blank? %>
+          <%= render "categories" %>
+          <%= render "shared/tag_cloud", taggable: "proposal" %>
+          <%= render "geozones" %>
+        <% end %>
+        <%= render "retired" %>
+        <%= render "proposals_lists" %>
+      </aside>
+    </div>
+
+  </div>
+</main>

--- a/app/views/custom/proposals/summary.html.erb
+++ b/app/views/custom/proposals/summary.html.erb
@@ -1,0 +1,55 @@
+<main>
+  <div class="row proposals-summary">
+    <div id="proposals" class="proposals-list small-12 medium-9 column">
+      <%= back_link_to %>
+
+      <% @proposals.each do |group_name, proposals| %>
+        <div id="<%= group_name.parameterize %>">
+          <h2 class="margin-top"><%= group_name %></h2>
+
+          <% proposals[0..2].each do |proposal| %>
+            <div class="proposal clear">
+              <div class="panel">
+                <div class="row">
+                  <div class="small-12 medium-9 column">
+                    <div class="proposal-contenta">
+                      <h3><%= link_to proposal.title, namespaced_proposal_path(proposal) %></h3>
+
+                      <p class="proposal-info">
+                        <% if proposal.author.hidden? || proposal.author.erased? %>
+                          <span class="author"><%= t("proposals.show.author_deleted") %></span>
+                        <% else %>
+                          <span class="author"><%= proposal.author.name %></span>
+                          <% if proposal.author.display_official_position_badge? %>
+                            <span class="label round level-<%= proposal.author.official_level %>">
+                              <%= proposal.author.official_position %>
+                            </span>
+                          <% end %>
+                        <% end %>
+                      </p>
+
+                      <div class="proposal-description">
+                        <p><%= proposal.summary %></p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="small-12 medium-3 column">
+      <aside class="sidebar">
+        <% if can? :create, Proposal %>
+          <%= link_to t("proposals.index.start_proposal"), new_proposal_path, class: "button radius expand" %>
+        <% end %>
+        <%= render "shared/tag_cloud", taggable: "proposal" %>
+        <%= render "categories" %>
+        <%= render "geozones" %>
+      </aside>
+    </div>
+  </div>
+</main>

--- a/app/views/custom/shared/_map.html.erb
+++ b/app/views/custom/shared/_map.html.erb
@@ -1,0 +1,44 @@
+<div class="row">
+  <div class="small-12 medium-9 column margin-top">
+
+    <h1><%= t("map.title") %></h1>
+
+    <div class="row">
+      <div class="small-12 medium-3 column">
+        <ul id="geozones" class="no-bullet">
+          <% @geozones.each do |geozone| %>
+            <li><%= link_to geozone.name, proposals_path(search: geozone.name) %></li>
+          <% end %>
+        </ul>
+      </div>
+
+      <div class="show-for-medium medium-9 column text-center">
+        <%= image_tag(image_path_for("map.jpg"), usemap: "#map") %>
+      </div>
+
+      <map name="map" id="html_map">
+        <% @geozones.each do |geozone| %>
+          <area shape="poly"
+                coords="<%= geozone.html_map_coordinates %>"
+                href="<%= polymorphic_path(@resource, search: geozone.name) %>"
+                title="<%= geozone.name %>"
+                alt="<%= geozone.name %>">
+        <% end %>
+      </map>
+    </div>
+
+    <% if can? :create, Proposal %>
+      <h2><%= t("map.proposal_for_district") %></h2>
+    <% end %>
+  </div>
+
+  <% if can? :create, Proposal %>
+    <div class="small-12 medium-3 column">
+      <aside class="sidebar">
+        <%= link_to t("map.start_proposal"),
+                    new_proposal_path, class: "button radius expand" %>
+        <%= render "shared/tag_cloud", taggable: "proposal" %>
+      </aside>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -1,4 +1,7 @@
 es:
+  account:
+    show:
+      user_permission_proposal: Crear nuevas propuestas*
   debates:
     index:
       section_header:


### PR DESCRIPTION
References
==========

Closes PopulateTools/issues#1082

Objectives
==========

* Change cancancan abilities to only allow to create proposals to verified users with geozone set
* Change new/edit proposal form to display in the geozone select the current user geozone
* Hide all references to create new proposals to users without permissions.
* Change the account show view to reflect the permission of current user to create proposals

Visual Changes (if any)
=======================

### Without permissions
<img width="967" alt="Screen Shot 2020-07-09 at 17 39 41" src="https://user-images.githubusercontent.com/446459/87061158-b24c6000-c20b-11ea-837b-ede4259a7657.png">
<img width="970" alt="Screen Shot 2020-07-09 at 17 41 58" src="https://user-images.githubusercontent.com/446459/87061154-b1b3c980-c20b-11ea-86f2-06f3653661d3.png">

### With permissions
<img width="441" alt="Screen Shot 2020-07-09 at 17 42 44" src="https://user-images.githubusercontent.com/446459/87061146-aeb8d900-c20b-11ea-808c-2430d644c518.png">
<img width="972" alt="Screen Shot 2020-07-09 at 17 42 26" src="https://user-images.githubusercontent.com/446459/87061152-b0829c80-c20b-11ea-8398-37013ae41ad3.png">
<img width="607" alt="Screen Shot 2020-07-09 at 17 45 15" src="https://user-images.githubusercontent.com/446459/87061425-06574480-c20c-11ea-87c0-45c88f6cd6c5.png">



Notes
=====================

