### PR TITLE
Hide valuation checkbox to close report

### DIFF
--- a/app/views/valuation/budget_investments/_dossier_form.html.erb
+++ b/app/views/valuation/budget_investments/_dossier_form.html.erb
@@ -66,6 +66,8 @@
 
   </div>
 
+  <% # Disabled until the process has finished %>
+  <% if false %>
   <div class="row">
     <div class="small-12 medium-8 column">
       <%= f.check_box :valuation_finished,
@@ -74,6 +76,7 @@
           "data-not-feasible-alert": t("valuation.budget_investments.edit.not_feasible_alert") %>
     </div>
   </div>
+  <% end %>
 
   <div class="row">
     <div class="actions small-12 medium-4 column">


### PR DESCRIPTION
Hides valuation report close confirmation. It should be enabled once the review has finished (around Sept 2021)