### PR TITLE
Replace fields on budget investment exporter

### DIFF
--- a/app/models/budget/investment/exporter.rb
+++ b/app/models/budget/investment/exporter.rb
@@ -41,7 +41,7 @@ class Budget::Investment::Exporter
       [
         investment.id.to_s,
         investment.title,
-        investment.description,
+        investment.description.squish,
         admin(investment),
         investment.assigned_valuators || "-",
         investment.assigned_valuation_groups || "-",

--- a/app/models/budget/investment/exporter.rb
+++ b/app/models/budget/investment/exporter.rb
@@ -23,13 +23,14 @@ class Budget::Investment::Exporter
       [
         I18n.t("admin.budget_investments.index.list.id"),
         I18n.t("admin.budget_investments.index.list.title"),
-        I18n.t("admin.budget_investments.index.list.supports"),
+        I18n.t("admin.budget_investments.index.list.description"),
         I18n.t("admin.budget_investments.index.list.admin"),
         I18n.t("admin.budget_investments.index.list.valuator"),
         I18n.t("admin.budget_investments.index.list.valuation_group"),
         I18n.t("admin.budget_investments.index.list.geozone"),
         I18n.t("admin.budget_investments.index.list.feasibility"),
         I18n.t("admin.budget_investments.index.list.valuation_finished"),
+        I18n.t("admin.budget_investments.index.list.unfeasibility_explanation"),
         I18n.t("admin.budget_investments.index.list.selected"),
         I18n.t("admin.budget_investments.index.list.visible_to_valuators"),
         I18n.t("admin.budget_investments.index.list.author_username")
@@ -40,13 +41,14 @@ class Budget::Investment::Exporter
       [
         investment.id.to_s,
         investment.title,
-        investment.total_votes.to_s,
+        investment.description,
         admin(investment),
         investment.assigned_valuators || "-",
         investment.assigned_valuation_groups || "-",
         investment.heading.name,
         price(investment),
         investment.valuation_finished? ? I18n.t("shared.yes") : I18n.t("shared.no"),
+        unfeasibility_explanation(investment),
         investment.selected? ? I18n.t("shared.yes") : I18n.t("shared.no"),
         investment.visible_to_valuators? ? I18n.t("shared.yes") : I18n.t("shared.no"),
         investment.author.username
@@ -68,6 +70,10 @@ class Budget::Investment::Exporter
       else
         I18n.t(price_string)
       end
+    end
+
+    def unfeasibility_explanation(investment)
+      investment.unfeasibility_explanation.presence || "-"
     end
 
     def json_values(investment)

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -277,6 +277,8 @@ en:
           incompatible: Incompatible
           price: Price
           author: Author
+          description: "Description"
+          unfeasibility_explanation: "Unfeasibility explanation"
         cannot_calculate_winners: The budget has to stay on phase "%{phase}" in order to calculate winners projects
         see_results: "See results"
         milestone_tags_filter_all: "All milestone tags"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -277,6 +277,8 @@ es:
           incompatible: Incompatible
           price: Precio
           author: Autor
+          description: "Descripción"
+          unfeasibility_explanation: "Informe de inviabilidad"
         cannot_calculate_winners: El presupuesto debe estar en la fase "%{phase}" para poder calcular las propuestas ganadoras
         see_results: "Ver resultados"
         milestone_tags_filter_all: "Todas las etiquetas de seguimiento"

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -1679,6 +1679,7 @@ describe "Admin budget investments", :admin do
       first_investment = create(:budget_investment, :feasible, :selected, title: "Le Investment",
                                                          budget: budget, group: budget_group,
                                                          heading: first_budget_heading,
+                                                         description: "My first investment!",
                                                          cached_votes_up: 88, price: 99,
                                                          valuators: [],
                                                          valuator_groups: [valuator_group],
@@ -1687,6 +1688,8 @@ describe "Admin budget investments", :admin do
       second_investment = create(:budget_investment, :unfeasible, title: "Alt Investment",
                                                          budget: budget, group: budget_group,
                                                          heading: second_budget_heading,
+                                                         description: "My second investment!",
+                                                         unfeasibility_explanation: "It is impossible",
                                                          cached_votes_up: 66, price: 88,
                                                          valuators: [valuator],
                                                          valuator_groups: [],
@@ -1700,13 +1703,14 @@ describe "Admin budget investments", :admin do
       expect(header).to match(/^attachment/)
       expect(header).to match(/filename="budget_investments.csv"$/)
 
-      csv_contents = "ID,Title,Supports,Administrator,Valuator,Valuation Group,Scope of operation,"\
-                     "Feasibility,Val. Fin.,Selected,Show to valuators,Author username\n"\
-                     "#{first_investment.id},Le Investment,88,Admin,-,Valuator Group,"\
-                     "Budget Heading,Feasible (€99),Yes,Yes,Yes,"\
+      csv_contents = "ID,Title,Description,Administrator,Valuator,Valuation Group,Scope of operation,"\
+                     "Feasibility,Val. Fin.,Unfeasibility explanation,Selected,"\
+                     "Show to valuators,Author username\n"\
+                     "#{first_investment.id},Le Investment,My first investment!,Admin,-,Valuator Group,"\
+                     "Budget Heading,Feasible (€99),Yes,-,Yes,Yes,"\
                      "#{first_investment.author.username}\n#{second_investment.id},"\
-                     "Alt Investment,66,No admin assigned,Valuator,-,Other Heading,"\
-                     "Unfeasible,No,No,No,#{second_investment.author.username}\n"
+                     "Alt Investment,My second investment!,No admin assigned,Valuator,-,Other Heading,"\
+                     "Unfeasible,No,It is impossible,No,No,#{second_investment.author.username}\n"
 
       expect(page.body).to eq(csv_contents)
     end


### PR DESCRIPTION
## Objectives

Replace fields on budget investment exporter: remove `supports`. Add `description` and `unfeasibility_explanation`.
