### PR TITLE
Fix bug rendering comments from a no longer existing user

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -2,7 +2,7 @@
 <% cache [locale_and_user_status(comment), comment, commentable_cache_key(comment.commentable), comment.author] do %>
   <div id="<%= dom_id(comment) %>" class="comment small-12">
     <div class="comment-body">
-      <% if comment.hidden? || comment.user.hidden? %>
+      <% if comment.hidden? || comment.user.nil? || comment.user.hidden? %>
         <% if comment.children.size > 0 %>
           <div class="callout secondary">
             <p><%= t("comments.comment.deleted") %></p>


### PR DESCRIPTION
## References

Error https://errors.democrateam.com/apps/62283909b2aa2902989942fb/problems/62a62d84d9d1af03e13053ba

## Objectives

Fix error when trying to render a comment from a no longer existing user in the database