### PR TITLE
Squish unfeasibility explanation on exporter

### DIFF
--- a/app/models/budget/investment/exporter.rb
+++ b/app/models/budget/investment/exporter.rb
@@ -73,7 +73,7 @@ class Budget::Investment::Exporter
     end
 
     def unfeasibility_explanation(investment)
-      investment.unfeasibility_explanation.presence || "-"
+      investment.unfeasibility_explanation&.squish.presence || "-"
     end
 
     def json_values(investment)


### PR DESCRIPTION
## Objectives

Squish unfeasibility explanation on exporter. This prevents a formatting error with line breaks when opening the file in Microsoft Excel.

