### PR TITLE
Add task to send emails to authors of unfeasible investments

### DIFF
--- a/app/assets/javascripts/investment_report_alert.js
+++ b/app/assets/javascripts/investment_report_alert.js
@@ -4,7 +4,7 @@
     initialize: function() {
       $("#js-investment-report-alert").on("click", function() {
         if (this.checked && $("#budget_investment_feasibility_unfeasible").is(":checked")) {
-          return confirm(this.dataset.alert + "\n" + this.dataset.notFeasibleAlert);
+          return confirm(this.dataset.alert);
         } else if (this.checked) {
           return confirm(this.dataset.alert);
         }

--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -27,10 +27,6 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
 
   def valuate
     if valid_price_params? && @investment.update(valuation_params)
-      if @investment.unfeasible_email_pending?
-        @investment.send_unfeasible_email
-      end
-
       Activity.log(current_user, :valuate, @investment)
       notice = t("valuation.budget_investments.notice.valuate")
       redirect_to valuation_budget_budget_investment_path(@budget, @investment), notice: notice

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -218,6 +218,12 @@ class Budget < ApplicationRecord
     end
   end
 
+  def email_unfeasible
+    investments.unfeasible.order(:id).each do |investment|
+      Mailer.budget_investment_unfeasible(investment).deliver_later
+    end
+  end
+
   def has_winning_investments?
     investments.winners.any?
   end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -241,10 +241,6 @@ class Budget
       feasible? && valuation_finished?
     end
 
-    def unfeasible_email_pending?
-      unfeasible_email_sent_at.blank? && unfeasible? && valuation_finished?
-    end
-
     def total_votes
       cached_votes_up + physical_votes
     end

--- a/app/views/mailer/budget_investment_unselected.html.erb
+++ b/app/views/mailer/budget_investment_unselected.html.erb
@@ -5,7 +5,8 @@
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= sanitize(t("mailers.budget_investment_unselected.text_1", title: @investment.title),
+    <%= sanitize(t("mailers.budget_investment_unselected.text_1",
+                 title: link_to(@investment.title, @investment, target: "_blank")),
                  attributes: %w[href target]) %>
   </p>
 

--- a/app/views/valuation/budget_investments/_dossier_form.html.erb
+++ b/app/views/valuation/budget_investments/_dossier_form.html.erb
@@ -71,8 +71,7 @@
     <div class="small-12 medium-8 column">
       <%= f.check_box :valuation_finished,
           id: "js-investment-report-alert",
-          "data-alert": t("valuation.budget_investments.edit.valuation_finished_alert"),
-          "data-not-feasible-alert": t("valuation.budget_investments.edit.not_feasible_alert") %>
+          "data-alert": t("valuation.budget_investments.edit.valuation_finished_alert") %>
     </div>
   </div>
  

--- a/config/locales/custom/es/mailers.yml
+++ b/config/locales/custom/es/mailers.yml
@@ -1,7 +1,7 @@
 es:
   mailers:
     budget_investment_unfeasible:
-      reconsider_html: "Lamentamos que tu propuesta no haya cumplido con los requisitos necesarios, pero te invitamos a que participes en las votaciones, que se celebrarán del 1 al 15 de septiembre, y decidas con tu voto qué proyectos se harán realidad el próximo año."
+      reconsider_html: "Lamentamos que tu propuesta no haya cumplido con los requisitos necesarios, pero te invitamos a que participes en las votaciones, que se celebrarán del 1 al 25 de septiembre, y decidas con tu voto qué proyectos se harán realidad el próximo año."
       signatory: "DIPUTACIÓN DE VALLADOLID"
       unfeasible_html: "Desde la Diputación queremos agradecer tu participación en los <strong>Presupuestos Participativos</strong>. Tu propuesta <strong>'%{title}'</strong> ha sido evaluada por el personal técnico de la Diputación, que ha considerado que es inviable. A continuación, puedes leer el informe de evaluación en el que se motiva dicha decisión:"
     user_invite:
@@ -10,5 +10,5 @@ es:
     budget_investment_selected:
       share: "Tu proyecto ha sido seleccionado y pasará a la fase de votación. Para que puede hacerse realidad es necesario que sea uno de los más votados en septiembre. Empieza ya a conseguir votos, comparte tu proyecto de gasto por correo electrónico, por mensaje o en redes sociales. La difusión es fundamental para conseguir que se haga realidad."
     budget_investment_unselected:
-      text_1: "A pesar de que tu proyecto <strong>'%{title}'</strong> fue considerado viable, tras aplicar el <a href=\"https://participa.diputaciondevalladolid.es/baremo\" target=\"_blank\">baremo técnico</a> ha obtenido menos puntuación que otros proyectos de la misma zona y, por tanto, no pasará a la fase de votación."
-      text_2: "A pesar de ello, te invitamos a que participes en las votaciones, que se celebrarán del 1 al 15 de septiembre y decidas con tu voto qué proyectos se harán realidad el próximo año."
+      text_1: "A pesar de que tu proyecto <strong>'%{title}'</strong> fue considerado viable, no está entre los que pasarán a la fase de votación. Si accedes al proyecto podrás ver la motivación que se ha dado para tomar esta decisión."
+      text_2: "A pesar de ello, te invitamos a que participes en las votaciones, que se celebrarán del 1 al 25 de septiembre y decidas con tu voto qué proyectos se harán realidad el próximo año."

--- a/config/locales/en/valuation.yml
+++ b/config/locales/en/valuation.yml
@@ -65,7 +65,6 @@ en:
         price_first_year: "Cost during the first year (%{currency}) <small>(optional, data not public)</small>"
         feasibility: Feasibility
         valuation_finished_alert: "Are you sure you want to mark this report as completed? If you do it, it can no longer be modified."
-        not_feasible_alert: "An email will be sent immediately to the author of the project with the report of unfeasibility."
         save: Save changes
       notice:
         valuate: "Dossier updated"

--- a/config/locales/es/valuation.yml
+++ b/config/locales/es/valuation.yml
@@ -65,7 +65,6 @@ es:
         price_first_year: "Coste en el primer año (%{currency}) <small>(opcional, dato no público)</small>"
         feasibility: Viabilidad
         valuation_finished_alert: "¿Estás seguro/a de querer marcar este informe como completado? Una vez hecho, no se puede deshacer la acción."
-        not_feasible_alert: "Un email será enviado inmediatamente al autor del proyecto con el informe de inviabilidad."
         save: Guardar cambios
       notice:
         valuate: "Dossier actualizado"

--- a/lib/tasks/budgets.rake
+++ b/lib/tasks/budgets.rake
@@ -9,5 +9,10 @@ namespace :budgets do
     task unselected: :environment do
       Budget.last.email_unselected
     end
+
+    desc "Sends emails to authors of unfeasible investments"
+    task unfeasible: :environment do
+      Budget.last.email_unfeasible
+    end
   end
 end


### PR DESCRIPTION
## Objectives

Add task to sent emails to authors of unfeasible investments instead of sending it automatically when the investment is marked as unfeasible and valuation finished.

## Notes

`bin/rake budgets:email:unfeasible RAILS_ENV=production`