### PR TITLE
BUGFIX: Do not show stats info from previous budgets

### DIFF
--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -82,7 +82,7 @@ class Admin::StatsController < Admin::BaseController
 
     @vote_count_by_heading = @budget.lines.group(:heading_id).count.map { |k, v| [Budget::Heading.find(k).name, v] }.sort
 
-    @user_count_by_district = User.where.not(balloted_heading_id: nil).group(:balloted_heading_id).count.map { |k, v| [Budget::Heading.find(k).name, v] }.sort
+    @user_count_by_district = User.where(balloted_heading_id: @budget.headings.map(&:id)).group(:balloted_heading_id).count.map { |k, v| [Budget::Heading.find(k).name, v] }.sort
   end
 
   def polls

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -183,7 +183,7 @@ describe "Stats", :admin do
       let(:budget) { create(:budget, :balloting) }
       let(:group) { create(:budget_group, budget: budget) }
       let(:heading) { create(:budget_heading, group: group) }
-      let!(:investment) { create(:budget_investment, :feasible, :selected, heading: heading) }
+      let(:investment) { create(:budget_investment, :feasible, :selected, heading: heading) }
 
       scenario "Number of votes in investment projects" do
         investment_2 = create(:budget_investment, :feasible, :selected, budget: budget)
@@ -212,6 +212,27 @@ describe "Stats", :admin do
         end
 
         expect(page).to have_content "PARTICIPANTS\n2"
+      end
+
+      scenario "Does not show participants per district from old budgets" do
+        old_budget = create(:budget, :balloting)
+        old_group = create(:budget_group, budget: old_budget)
+        old_heading = create(:budget_heading, group: old_group, name: "Old Heading")
+        old_investment = create(:budget_investment, :feasible, :selected, heading: old_heading)
+        create(:user, ballot_lines: [old_investment])
+        create(:user, ballot_lines: [old_investment])
+
+        create(:user, ballot_lines: [investment])
+
+        visit admin_stats_path
+        click_link "Participatory Budgets"
+        within("#budget_#{budget.id}") do
+          click_link "Final voting"
+        end
+        expect(page).to have_content "VOTES\n1"
+        expect(page).to have_content "PARTICIPANTS\n1"
+
+        expect(page).not_to have_content "Old Heading"
       end
     end
   end


### PR DESCRIPTION
## Objectives

Do not show information about participants per district from previous budgets in the stats page.

## Visual Changes
### BEFORE
![before](https://user-images.githubusercontent.com/942995/188054809-1bd532cc-7b73-4b09-9016-73a4fa4ffa00.png)

### AFTER
![after](https://user-images.githubusercontent.com/942995/188054829-e3ac001c-09ff-4aca-b741-a6be045725ef.png)