### PR TITLE
CENSUS: Format residence cards if they have less than 8 digits

### DIFF
--- a/lib/custom/census_caller.rb
+++ b/lib/custom/census_caller.rb
@@ -1,6 +1,8 @@
 class CensusCaller
 
   def call(document_type, document_number, postal_code)
+    document_number = DocumentParser.format_residence_card(document_number) if document_type.to_s == "3"
+
     response = CustomCensusApi.new.call(document_type, document_number, postal_code)
     return response if response.valid? && response.is_citizen?
 

--- a/lib/document_parser.rb
+++ b/lib/document_parser.rb
@@ -59,6 +59,23 @@ module DocumentParser
     variants
   end
 
+  # if the residence card has less than 8 digits, pad with zeros to the left until it has 8 digits
+  # For example:
+  # - if the residence card is Y1234567A, the result is Y01234567A
+  # - if the residence card is Y123456A,  the result is Y00123456A
+  def format_residence_card(document_number)
+    first_letter = document_number.chars.first
+    last_letter = document_number.chars.last
+
+    digits = document_number.remove(first_letter).remove(last_letter)
+
+    (8 - digits.size).times do
+      digits = "0#{digits}"
+    end
+
+    "#{first_letter}#{digits}#{last_letter}"
+  end
+
   def dni?(document_type)
     document_type.to_s == "1"
   end

--- a/spec/lib/document_parser_spec.rb
+++ b/spec/lib/document_parser_spec.rb
@@ -29,4 +29,20 @@ describe DocumentParser do
       expect(DocumentParser.get_document_number_variants(1, "1234567A")).to eq(%w[1234567 01234567 1234567a 1234567A 01234567a 01234567A])
     end
   end
+
+  describe "#format_residence_card" do
+    it "does nothing if residence card has 8 digits" do
+      expect(DocumentParser.format_residence_card("Y12345678A")).to eq("Y12345678A")
+    end
+
+    it "adds zeroes to the left if residence card does not have 8 digits" do
+      expect(DocumentParser.format_residence_card("Y1234567A")).to eq("Y01234567A")
+      expect(DocumentParser.format_residence_card("Y123456A")).to eq("Y00123456A")
+      expect(DocumentParser.format_residence_card("Y12345A")).to eq("Y00012345A")
+      expect(DocumentParser.format_residence_card("Y1234A")).to eq("Y00001234A")
+      expect(DocumentParser.format_residence_card("Y123A")).to eq("Y00000123A")
+      expect(DocumentParser.format_residence_card("Y12A")).to eq("Y00000012A")
+      expect(DocumentParser.format_residence_card("Y1A")).to eq("Y00000001A")
+    end
+  end
 end


### PR DESCRIPTION
## Objectives

Use the correct format for the Census API for residence cards.
If the residence card has less than 8 digits, zeroes have to be added to the left until the number of digits is 8.

- If the residence card is `Y1234567A`, we must use `Y01234567A`
- If the residence card is `Y123456A`, we must use `Y00123456A`
- And so on...